### PR TITLE
Add text-wrapper tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,6 +327,20 @@
                     </div>
                 </a>
 
+                <a href="/text-wrapper/" class="tool-entry">
+                    <div class="tool-header">
+                        <div class="tool-name">TEXT_WRAPPER</div>
+                        <div class="tool-status">[ONLINE]</div>
+                    </div>
+                    <div class="tool-body">
+                        <div class="tool-description">
+                            Wrap text to a specific line length with syntax awareness.
+                            Preserves indentation and avoids breaking URLs. Default: 100 characters.
+                        </div>
+                        <div class="tool-path">$ cd /text-wrapper/</div>
+                    </div>
+                </a>
+
                 <a href="/uc-schools-map/" class="tool-entry">
                     <div class="tool-header">
                         <div class="tool-name">UC_SCHOOLS_MAP</div>
@@ -353,7 +367,7 @@
                 </div>
                 <div class="info-line">
                     <span class="info-label">TOOLS_LOADED:</span>
-                    <span class="info-value">5</span>
+                    <span class="info-value">6</span>
                 </div>
                 <div class="info-line">
                     <span class="info-label">BASE_URL:</span>

--- a/tools/text-wrapper/index.html
+++ b/tools/text-wrapper/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Text Wrapper - Vibed Tool</title>
+    <link rel="stylesheet" href="/common.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="terminal">
+        <div class="window">
+            <div class="nav-header">
+                <a href="/" class="back-link">← BACK TO TOOLS</a>
+            </div>
+            <h1>TEXT WRAPPER</h1>
+            <p class="subtitle">Wrap text to a specific line length with syntax awareness</p>
+
+            <div class="input-section">
+                <div class="input-group">
+                    <label for="wrapLength">WRAP LENGTH (CHARACTERS):</label>
+                    <div class="input-line">
+                        <span class="prompt">$ </span>
+                        <input type="text" id="wrapLength" value="100" maxlength="4">
+                    </div>
+                </div>
+
+                <div class="input-group">
+                    <label for="inputText">INPUT TEXT:</label>
+                    <textarea id="inputText" placeholder="Paste or type text here to wrap..."></textarea>
+                </div>
+
+                <div class="input-group">
+                    <label>
+                        <input type="checkbox" id="syntaxAware" checked>
+                        <span class="checkbox-label">Syntax-aware (preserve indentation, don't break URLs)</span>
+                    </label>
+                </div>
+
+                <div class="controls">
+                    <button id="wrapBtn">[WRAP TEXT]</button>
+                    <button id="clearBtn">[CLEAR]</button>
+                </div>
+            </div>
+
+            <div id="outputSection" class="output-section hidden">
+                <div class="output">
+                    <div class="input-line">
+                        <span class="prompt">> </span>
+                        <span>OUTPUT</span>
+                        <button class="copy-btn" id="copyBtn">[COPY]</button>
+                    </div>
+                    <textarea id="outputText" readonly></textarea>
+                </div>
+            </div>
+
+            <div class="status">
+                <p>TOOL_URL: tools.apps.alexbrand.dev/text-wrapper/</p>
+                <p>STATUS: ONLINE</p>
+                <p>DEFAULT_WRAP: 100 CHARS</p>
+            </div>
+        </div>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/tools/text-wrapper/script.js
+++ b/tools/text-wrapper/script.js
@@ -1,0 +1,205 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const wrapLengthInput = document.getElementById('wrapLength');
+    const inputText = document.getElementById('inputText');
+    const outputText = document.getElementById('outputText');
+    const outputSection = document.getElementById('outputSection');
+    const wrapBtn = document.getElementById('wrapBtn');
+    const clearBtn = document.getElementById('clearBtn');
+    const copyBtn = document.getElementById('copyBtn');
+    const syntaxAwareCheckbox = document.getElementById('syntaxAware');
+
+    // URL regex pattern to detect URLs
+    const URL_PATTERN = /https?:\/\/[^\s]+/g;
+
+    function wrapText() {
+        const text = inputText.value;
+        const wrapLength = parseInt(wrapLengthInput.value) || 100;
+        const syntaxAware = syntaxAwareCheckbox.checked;
+
+        if (!text.trim()) {
+            outputSection.classList.add('hidden');
+            return;
+        }
+
+        if (wrapLength < 10 || wrapLength > 9999) {
+            alert('ERROR: Wrap length must be between 10 and 9999');
+            return;
+        }
+
+        const wrappedText = syntaxAware
+            ? wrapTextSyntaxAware(text, wrapLength)
+            : wrapTextSimple(text, wrapLength);
+
+        outputText.value = wrappedText;
+        outputSection.classList.remove('hidden');
+    }
+
+    function wrapTextSimple(text, maxLength) {
+        const lines = text.split('\n');
+        const wrappedLines = [];
+
+        for (const line of lines) {
+            if (line.length <= maxLength) {
+                wrappedLines.push(line);
+            } else {
+                wrappedLines.push(...breakLine(line, maxLength));
+            }
+        }
+
+        return wrappedLines.join('\n');
+    }
+
+    function wrapTextSyntaxAware(text, maxLength) {
+        const lines = text.split('\n');
+        const wrappedLines = [];
+
+        for (const line of lines) {
+            // Detect indentation
+            const indentMatch = line.match(/^(\s*)/);
+            const indent = indentMatch ? indentMatch[1] : '';
+            const contentStartIndex = indent.length;
+
+            if (line.length <= maxLength) {
+                wrappedLines.push(line);
+                continue;
+            }
+
+            // Check if line contains URLs
+            const urls = [];
+            const urlMatches = line.matchAll(URL_PATTERN);
+            for (const match of urlMatches) {
+                urls.push({
+                    url: match[0],
+                    start: match.index,
+                    end: match.index + match[0].length
+                });
+            }
+
+            // If line has URLs, try not to break them
+            if (urls.length > 0) {
+                const broken = breakLineWithURLs(line, maxLength, indent, urls);
+                wrappedLines.push(...broken);
+            } else {
+                // Standard break with indentation preservation
+                const broken = breakLine(line, maxLength, indent);
+                wrappedLines.push(...broken);
+            }
+        }
+
+        return wrappedLines.join('\n');
+    }
+
+    function breakLine(line, maxLength, indent = '') {
+        const lines = [];
+        let currentLine = line;
+
+        while (currentLine.length > maxLength) {
+            // Try to break at a space
+            let breakPoint = currentLine.lastIndexOf(' ', maxLength);
+
+            if (breakPoint === -1 || breakPoint < maxLength / 2) {
+                // No good break point found, hard break
+                breakPoint = maxLength;
+            }
+
+            lines.push(currentLine.substring(0, breakPoint));
+            currentLine = indent + currentLine.substring(breakPoint).trim();
+        }
+
+        if (currentLine.trim()) {
+            lines.push(currentLine);
+        }
+
+        return lines;
+    }
+
+    function breakLineWithURLs(line, maxLength, indent, urls) {
+        const lines = [];
+        let pos = 0;
+        let currentLine = '';
+
+        // Process the line segment by segment
+        for (let i = 0; i < urls.length; i++) {
+            const url = urls[i];
+
+            // Add text before URL
+            const textBefore = line.substring(pos, url.start);
+
+            // If adding this text would exceed limit, break before it
+            if ((currentLine + textBefore).length > maxLength && currentLine.trim()) {
+                lines.push(currentLine.trimEnd());
+                currentLine = indent + textBefore.trim();
+            } else {
+                currentLine += textBefore;
+            }
+
+            // Add URL - don't break it if possible
+            if ((currentLine + url.url).length > maxLength && currentLine.trim()) {
+                // URL won't fit on current line, start new line
+                lines.push(currentLine.trimEnd());
+                currentLine = indent + url.url;
+            } else {
+                currentLine += url.url;
+            }
+
+            pos = url.end;
+        }
+
+        // Add remaining text after last URL
+        const remaining = line.substring(pos);
+        if (remaining) {
+            if ((currentLine + remaining).length > maxLength && currentLine.trim()) {
+                lines.push(currentLine.trimEnd());
+                const brokenRemaining = breakLine(indent + remaining.trim(), maxLength, indent);
+                lines.push(...brokenRemaining);
+            } else {
+                currentLine += remaining;
+                if (currentLine.trim()) {
+                    lines.push(currentLine);
+                }
+            }
+        } else if (currentLine.trim()) {
+            lines.push(currentLine);
+        }
+
+        return lines;
+    }
+
+    function clearAll() {
+        inputText.value = '';
+        outputText.value = '';
+        outputSection.classList.add('hidden');
+        inputText.focus();
+    }
+
+    function copyToClipboard() {
+        outputText.select();
+        document.execCommand('copy');
+
+        const originalText = copyBtn.textContent;
+        copyBtn.textContent = '[COPIED!]';
+        setTimeout(() => {
+            copyBtn.textContent = originalText;
+        }, 1500);
+    }
+
+    // Event listeners
+    wrapBtn.addEventListener('click', wrapText);
+    clearBtn.addEventListener('click', clearAll);
+    copyBtn.addEventListener('click', copyToClipboard);
+
+    // Wrap on Enter in wrap length input
+    wrapLengthInput.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            wrapText();
+        }
+    });
+
+    // Allow only numbers in wrap length input
+    wrapLengthInput.addEventListener('input', (e) => {
+        e.target.value = e.target.value.replace(/[^0-9]/g, '');
+    });
+
+    // Focus input on load
+    inputText.focus();
+});

--- a/tools/text-wrapper/style.css
+++ b/tools/text-wrapper/style.css
@@ -1,0 +1,35 @@
+/* Text Wrapper Tool - Specific Overrides */
+
+.window {
+    max-width: 1000px;
+}
+
+textarea {
+    min-height: 200px;
+}
+
+#outputText {
+    min-height: 250px;
+}
+
+.input-group label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.checkbox-label {
+    color: #e6e6e6;
+    font-size: 0.9rem;
+}
+
+input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    accent-color: #e6e6e6;
+}
+
+#wrapLength {
+    max-width: 100px;
+}


### PR DESCRIPTION
Implements issue #4

Adds a new text wrapping tool with:
- Default wrap length of 100 characters (configurable)
- Syntax-aware mode that preserves indentation and avoids breaking URLs
- Clean terminal aesthetic following project guidelines
- Copy to clipboard functionality

Generated with [Claude Code](https://claude.ai/code)